### PR TITLE
fix rsync path for production website

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Rsync documentation to destination
         run: |
           ls -l site
-          rsync -avz --delete site/* /hpc/websites/hpc.czbiohub.org/
+          rsync -avz --delete site/* /hpc/websites/hpc.czbiohub.org/html


### PR DESCRIPTION
@willthelaw i believe the error we faced last time was that the rsync path was incorrect.  With this change i have now corrected this to `/var/www/hpc.czbiohub.org/html`