### PR TITLE
Add hardware specs for CHI and CZII

### DIFF
--- a/docs/hardware/overview.md
+++ b/docs/hardware/overview.md
@@ -5,8 +5,18 @@ description: Description/listing of what resources are currently in Bruno
 # Hardware
 
 ## Bruno
+
+| Category       | Count  |
+|---------------|--------|
+| Total CPUs    | 5568   |
+| Total GPUs    | 216    |
+| Total Nodes   | 96     |
+| Login Nodes   | 2      |
+| CPU Nodes     | 14     |
+| GPU Nodes     | 80     |
+
 | Name               | Cores    | CPU Type                  | Memory      | GPUs                |
-| ------------------ | -------: | :-----------------------: | ----------: | ------------------- |
+| ------------------ |----------|---------------------------|-------------| ------------------- |
 | `login-[01-02]`    | 128/node | AMD Epyc 7003             | 1 TB/node   | none                |
 | `login-fry1`       | 16/node  | INTEL Xeon E5 2609 v4     | 512 GB      | 4 x TitanXP         |
 | `login-fry2`       | 16/node  | INTEL Xeon E5 2609 v4     | 256 GB      | 4 x TitanXP         |
@@ -26,22 +36,17 @@ description: Description/listing of what resources are currently in Bruno
 | `gpu-sm01-[01-20]` | 16/node  | AMD Epyc 7302P            | 256 GB/node | 1 x A40 / node      |
 | `gpu-sm02-[01-20]` | 16/node  | AMD Epyc 7302P            | 256 GB/node | 1 x A40 / node      |
 
-* Total User Partitions CPU cores: 5568
-* Total GPUs: 216
 
-<hr>
-
-### GPU Summary
-
-| GPU Type       | Bruno Total |
-| :------------: | :---------: |
-| A100 (40 GB)   | 16          |
-| A100 (80 GB)   | 8           |
-| A6000 (48 GB)  | 24          |
-| A40 (48GB)     | 56          |
-| H100 (80 GB)   | 48          |
-| H200 (141 GB)  | 56          |
-| L40S (48 GB)   | 8           |
+| GPU Type      | Bruno Total |
+|---------------|-------------|
+| A100 (40 GB)  | 16          |
+| A100 (80 GB)  | 8           |
+| A6000 (48 GB) | 24          |
+| A40 (48GB)    | 56          |
+| H100 (80 GB)  | 48          |
+| H200 (141 GB) | 56          |
+| L40S (48 GB)  | 8           |
+| Total GPUs    | 216         |
 
 
 ### Storage Nodes/Appliances
@@ -60,14 +65,22 @@ description: Description/listing of what resources are currently in Bruno
 
 ## CZII
 
-| Name               | Cores      | CPU Type                                     | Memory      | GPUs                 |
-|--------------------|-----------|----------------------------------------------|------------|----------------------|
-| `czii-login[1-2]`  | 64/node   | AMD EPYC 9354P 32-Core Processor            | 514GB/node | none                 |
-| `czii-cpu-a-[1-2]` | 128/node  | AMD EPYC 9534 64-Core Processor             | 2.3TB/node | none                 |
-| `czii-gpu-a-[1-2]` | 16/node   | Intel(R) Xeon(R) Gold 6326 CPU @ 2.90GHz    | 1T/node    | 2x NVIDIA A40        |
-| `czii-gpu-b-[1-3]` | 64/node   | AMD EPYC 9184X 16-Core Processor            | 1.5TB/node | 8x NVIDIA RTX A6000  |
-| `czii-gpu-c-[1-3]` | 128/node  | AMD EPYC 9334 32-Core Processor             | 2.3TB/node | 4x NVIDIA A40        |
-| `czii-gpu-d-1`     | 128/node  | Intel(R) Xeon(R) Gold 6438Y+                | 1T/node    | 4x NVIDIA RTX 6000   |
+| Name               | Cores      | CPU Type                                     | Memory      | GPUs                |
+|--------------------|-----------|----------------------------------------------|------------|---------------------|
+| `czii-login[1-2]`  | 64/node   | AMD EPYC 9354P 32-Core Processor            | 514GB/node | none                |
+| `czii-cpu-a-[1-2]` | 128/node  | AMD EPYC 9534 64-Core Processor             | 2.3TB/node | none                |
+| `czii-gpu-a-[1-2]` | 16/node   | Intel(R) Xeon(R) Gold 6326 CPU @ 2.90GHz    | 1T/node    | 2x NVIDIA A40       |
+| `czii-gpu-b-[1-3]` | 64/node   | AMD EPYC 9184X 16-Core Processor            | 1.5TB/node | 8x NVIDIA RTX A6000 |
+| `czii-gpu-c-[1-3]` | 128/node  | AMD EPYC 9334 32-Core Processor             | 2.3TB/node | 4x NVIDIA A40       |
+| `czii-gpu-d-1`     | 128/node  | Intel(R) Xeon(R) Gold 6438Y+                | 1T/node    | 4x NVIDIA RTX A6000 |
+
+
+| GPU Type          | Total |
+|-------------------|-------|
+| A40               | 16    |
+| RTX A6000 (48 GB) | 28    |
+| Total GPUs        | 44    |
+
 
 ## CHI
 

--- a/docs/hardware/overview.md
+++ b/docs/hardware/overview.md
@@ -5,25 +5,25 @@ description: Description/listing of what resources are currently in Bruno
 # Hardware
 
 ## Bruno
-| Name              | Cores     | CPU Type | Memory      | TmpFS    | GPUs                | GPU Type |
-| ----------------- | --------: | :------: | ----------: | -------: | ------------------: | :------: |
-|`login-[01-02]`    |  128/node |  AMD Epyc 7003   | 1 TB/node   | 4 TB     | none                | N/A      |
-|`login-fry1`       |  16/node  |  INTEL Xeon E5 2609 v4   | 512 GB      | 15 TB    | 4 x TitanXP         | PCIe     |
-|`login-fry2`       |  16/node  |  INTEL Xeon E5 2609 v4   | 256 GB      | 15 TB    | 4 x TitanXP         | PCIe     |
-|`login-falcon`     |  32/node  |  INTEL Xeon E5 2667 v4  | 256 GB      | 85 TB    | 3 x TitanRTX        | PCIe     |
-|`cpu-a-[1-2]`      |  128/node |  AMD Epyc 7H12   | 4 TB/node   | 4 TB     | none                | N/A      |
-|`cpu-b-[1-6]`      |  128/node |  AMD Epyc 7H12   | 4 TB/node   | 4 TB     | none                | N/A      |
-|`cpu-c-[1-4]`      |  24/node  |  INTEL Xeon Gold 6126  | 128 GB/node | 4 TB     | none                | N/A      |
-|`cpu-d-1`          |  32/node  |  AMD Epyc 7601   | 2 TB/node   | 6.5 TB   | none                | N/A      |
-|`cpu-e-[1-2]`      |  128/node |  AMD Epyc 7763   | 4 TB/node   | 4 TB     | none                | N/A      |
-|`gpu-a-[1-4]`      |  128/node |  AMD Epyc 7742   | 2 TB/node   | 14 TB    | 4 x A100(40GB)/node | SXM4     |
-|`gpu-b-[1-6]`      |  128/node |  AMD Epyc 7742   | 512 GB/node | 14 TB    | 4 x A6000/node      | PCIe     |
-|`gpu-c-1`      |  30/node  |  AMD Epyc 7773X   | 480 GB/node | 7 TB     | 8 x A40 / node      | PCIe SLI |
-|`gpu-d-[1-2]`      |  128/node |  AMD Epyc 7773X   | 2 TB/node   | 45 TB    | 4 x A100(80GB)/node | SXM4     |
-|`gpu-e-[1-8]`      |  16/node  |  AMD Epyc 7313P   | 512 GB/node | 7 TB     | 1 x A40 / node      | PCIe     |
-|`gpu-f-[1-6]` |  112/node  |  INTEL Xeon Platinum 8480c   | 2 TB/node | 2 TB   | 8 x H100 / node      | SXM4     |
-|`gpu-sm01-[01-20]` |  16/node  |  AMD Epyc 7302P   | 256 GB/node | 1.8 TB   | 1 x A40 / node      | PCIe     |
-|`gpu-sm02-[01-20]` |  16/node  |  AMD Epyc 7302P   | 256 GB/node | 1.8 TB   | 1 x A40 / node      | PCIe     |
+| Name              | Cores     | CPU Type | Memory      | GPUs         |  
+| ----------------- | --------: | :------: | ----------: |--------------|
+|`login-[01-02]`    |  128/node |  AMD Epyc 7003   | 1 TB/node   | none         |
+|`login-fry1`       |  16/node  |  INTEL Xeon E5 2609 v4   | 512 GB      | 4 x TitanXP  |
+|`login-fry2`       |  16/node  |  INTEL Xeon E5 2609 v4   | 256 GB      | 4 x TitanXP  |
+|`login-falcon`     |  32/node  |  INTEL Xeon E5 2667 v4  | 256 GB      | 3 x TitanRTX |
+|`cpu-a-[1-2]`      |  128/node |  AMD Epyc 7H12   | 4 TB/node   |  none                |
+|`cpu-b-[1-6]`      |  128/node |  AMD Epyc 7H12   | 4 TB/node   |  none                |
+|`cpu-c-[1-4]`      |  24/node  |  INTEL Xeon Gold 6126  | 128 GB/node |  none          |
+|`cpu-d-1`          |  32/node  |  AMD Epyc 7601   | 2 TB/node   |  none                |
+|`cpu-e-[1-2]`      |  128/node |  AMD Epyc 7763   | 4 TB/node   |  none                |
+|`gpu-a-[1-4]`      |  128/node |  AMD Epyc 7742   | 2 TB/node   | 4 x A100(40GB)/node |
+|`gpu-b-[1-6]`      |  128/node |  AMD Epyc 7742   | 512 GB/node | 4 x A6000/node      |
+|`gpu-c-1`      |  30/node  |  AMD Epyc 7773X   | 480 GB/node | 8 x A40 / node      |
+|`gpu-d-[1-2]`      |  128/node |  AMD Epyc 7773X   | 2 TB/node   | 4 x A100(80GB)/node |
+|`gpu-e-[1-8]`      |  16/node  |  AMD Epyc 7313P   | 512 GB/node |  1 x A40 / node      |
+|`gpu-f-[1-6]` |  112/node  |  INTEL Xeon Platinum 8480c   | 2 TB/node |  8 x H100 / node  |
+|`gpu-sm01-[01-20]` |  16/node  |  AMD Epyc 7302P   | 256 GB/node | 1 x A40 / node      |
+|`gpu-sm02-[01-20]` |  16/node  |  AMD Epyc 7302P   | 256 GB/node | 1 x A40 / node      |
 
 
 *Note: Change*

--- a/docs/hardware/overview.md
+++ b/docs/hardware/overview.md
@@ -2,8 +2,9 @@
 title: Bruno Infrastructure
 description: Description/listing of what resources are currently in Bruno
 ---
-# Nodes
+# Hardware
 
+## Bruno
 | Name              | Cores     | CPU Type | Memory      | TmpFS    | GPUs                | GPU Type |
 | ----------------- | --------: | :------: | ----------: | -------: | ------------------: | :------: |
 |`login-[01-02]`    |  128/node |  AMD Epyc 7003   | 1 TB/node   | 4 TB     | none                | N/A      |
@@ -23,7 +24,7 @@ description: Description/listing of what resources are currently in Bruno
 |`gpu-f-[1-6]` |  112/node  |  INTEL Xeon Platinum 8480c   | 2 TB/node | 2 TB   | 8 x H100 / node      | SXM4     |
 |`gpu-sm01-[01-20]` |  16/node  |  AMD Epyc 7302P   | 256 GB/node | 1.8 TB   | 1 x A40 / node      | PCIe     |
 |`gpu-sm02-[01-20]` |  16/node  |  AMD Epyc 7302P   | 256 GB/node | 1.8 TB   | 1 x A40 / node      | PCIe     |
-[ Computational Resources ]
+
 
 *Note: Change*
 
@@ -36,7 +37,7 @@ description: Description/listing of what resources are currently in Bruno
 
 <hr>
 
-# GPU Summary
+### GPU Summary
 
 | GPU Type       | Bruno Total            |
 | :------------: | :--------------------: |
@@ -45,9 +46,9 @@ description: Description/listing of what resources are currently in Bruno
 | A6000 (48 GB)  | 24                     |
 | A40 (48GB)     | 48                     |
 | H100 (80 GB) | 48 |
-[ GPU Totals by type ]
 
-# Storage Nodes/Appliances
+
+### Storage Nodes/Appliances
 
 
 | Name                 | FileSystem   | Size        |
@@ -60,6 +61,28 @@ description: Description/listing of what resources are currently in Bruno
 | DDN Appliance EXA1   | Lustre       | 5.9 PB      |
 | VAST             | VAST/\[p]NFS | 1 PB        |
 [ Storage servers and appliances ]
+
+## CZII
+
+| Name               | Cores      | CPU Type                                     | Memory      | GPUs                 |
+|--------------------|-----------|----------------------------------------------|------------|----------------------|
+| `czii-login[1-2]`  | 64/node   | AMD EPYC 9354P 32-Core Processor            | 514GB/node | none                 |
+| `czii-cpu-a-[1-2]` | 128/node  | AMD EPYC 9534 64-Core Processor             | 2.3TB/node | none                 |
+| `czii-gpu-a-[1-2]` | 16/node   | Intel(R) Xeon(R) Gold 6326 CPU @ 2.90GHz    | 1T/node    | 2x NVIDIA A40        |
+| `czii-gpu-b-[1-3]` | 64/node   | AMD EPYC 9184X 16-Core Processor            | 1.5TB/node | 8x NVIDIA RTX A6000  |
+| `czii-gpu-c-[1-3]` | 128/node  | AMD EPYC 9334 32-Core Processor             | 2.3TB/node | 4x NVIDIA A40        |
+| `czii-gpu-d-1`     | 128/node  | Intel(R) Xeon(R) Gold 6438Y+                | 1T/node    | 4x NVIDIA RTX 6000   |
+
+## CHI 
+
+
+| Name               | Cores   | CPU Type                         | Memory    | GPUs |
+|--------------------|---------|----------------------------------|-----------|------|
+| `chi-login[1-2]`   | 16/node | AMD EPYC 9354P 32-Core Processor | 128G/node | none |
+| `chi-cpu-a-[1-2]`  | -       | -                                | -         | -    |
+| `chi-cpu-vm-a-[1-2]` | -       | -                                | -         | -    |
+| `chi-gpu-a-1` | -       | -                                | -         | -    |
+
 
 # Network View
 

--- a/docs/hardware/overview.md
+++ b/docs/hardware/overview.md
@@ -85,12 +85,14 @@ description: Description/listing of what resources are currently in Bruno
 ## CHI
 
 
-| Name               | Cores   | CPU Type                         | Memory    | GPUs |
-|--------------------|---------|----------------------------------|-----------|------|
-| `chi-login[1-2]`   | 16/node | AMD EPYC 9354P 32-Core Processor | 128G/node | none |
-| `chi-cpu-a-[1-2]`  | -       | -                                | -         | -    |
-| `chi-cpu-vm-a-[1-2]` | -       | -                                | -         | -    |
-| `chi-gpu-a-1` | -       | -                                | -         | -    |
+| Name               | Cores    | CPU Type                       | Memory    | GPUs           |
+|--------------------|----------|--------------------------------|-----------|----------------|
+| `chi-login[1-2]`   | 16/node  | AMD EPYC 9354P 32-Core Processor | 128G/node | none           |
+| `chi-cpu-a-[1-2]`  | 256/node | AMD EPYC 9754                  | 2.3T/node | none           |
+| `chi-cpu-b-[1-2]`  | 256/node | AMD EPYC 9754                  | 1.5T/node | none           |
+| `chi-cpu-vm-a-[1-2]` | 8/nodes  | AMD EPYC 9534                | 128G/node | none           |
+| `chi-gpu-a-1` | 256/node | AMD EPYC 9754 128-Core Processor    | 2.3T/node | 8x NVIDIA H200 |
+
 
 
 # Network View

--- a/docs/hardware/overview.md
+++ b/docs/hardware/overview.md
@@ -5,47 +5,43 @@ description: Description/listing of what resources are currently in Bruno
 # Hardware
 
 ## Bruno
-| Name              | Cores     | CPU Type | Memory      | GPUs         |  
-| ----------------- | --------: | :------: | ----------: |--------------|
-|`login-[01-02]`    |  128/node |  AMD Epyc 7003   | 1 TB/node   | none         |
-|`login-fry1`       |  16/node  |  INTEL Xeon E5 2609 v4   | 512 GB      | 4 x TitanXP  |
-|`login-fry2`       |  16/node  |  INTEL Xeon E5 2609 v4   | 256 GB      | 4 x TitanXP  |
-|`login-falcon`     |  32/node  |  INTEL Xeon E5 2667 v4  | 256 GB      | 3 x TitanRTX |
-|`cpu-a-[1-2]`      |  128/node |  AMD Epyc 7H12   | 4 TB/node   |  none                |
-|`cpu-b-[1-6]`      |  128/node |  AMD Epyc 7H12   | 4 TB/node   |  none                |
-|`cpu-c-[1-4]`      |  24/node  |  INTEL Xeon Gold 6126  | 128 GB/node |  none          |
-|`cpu-d-1`          |  32/node  |  AMD Epyc 7601   | 2 TB/node   |  none                |
-|`cpu-e-[1-2]`      |  128/node |  AMD Epyc 7763   | 4 TB/node   |  none                |
-|`gpu-a-[1-4]`      |  128/node |  AMD Epyc 7742   | 2 TB/node   | 4 x A100(40GB)/node |
-|`gpu-b-[1-6]`      |  128/node |  AMD Epyc 7742   | 512 GB/node | 4 x A6000/node      |
-|`gpu-c-1`      |  30/node  |  AMD Epyc 7773X   | 480 GB/node | 8 x A40 / node      |
-|`gpu-d-[1-2]`      |  128/node |  AMD Epyc 7773X   | 2 TB/node   | 4 x A100(80GB)/node |
-|`gpu-e-[1-8]`      |  16/node  |  AMD Epyc 7313P   | 512 GB/node |  1 x A40 / node      |
-|`gpu-f-[1-6]` |  112/node  |  INTEL Xeon Platinum 8480c   | 2 TB/node |  8 x H100 / node  |
-|`gpu-sm01-[01-20]` |  16/node  |  AMD Epyc 7302P   | 256 GB/node | 1 x A40 / node      |
-|`gpu-sm02-[01-20]` |  16/node  |  AMD Epyc 7302P   | 256 GB/node | 1 x A40 / node      |
+| Name               | Cores    | CPU Type                  | Memory      | GPUs                |
+| ------------------ | -------: | :-----------------------: | ----------: | ------------------- |
+| `login-[01-02]`    | 128/node | AMD Epyc 7003             | 1 TB/node   | none                |
+| `login-fry1`       | 16/node  | INTEL Xeon E5 2609 v4     | 512 GB      | 4 x TitanXP         |
+| `login-fry2`       | 16/node  | INTEL Xeon E5 2609 v4     | 256 GB      | 4 x TitanXP         |
+| `login-falcon`     | 32/node  | INTEL Xeon E5 2667 v4     | 256 GB      | 3 x TitanRTX        |
+| `cpu-a-[1-2]`      | 128/node | AMD Epyc 7H12             | 4 TB/node   | none                |
+| `cpu-b-[1-6]`      | 128/node | AMD Epyc 7H12             | 4 TB/node   | none                |
+| `cpu-c-[1-4]`      | 24/node  | INTEL Xeon Gold 6126      | 128 GB/node | none                |
+| `cpu-e-[1-2]`      | 128/node | AMD Epyc 7763             | 4 TB/node   | none                |
+| `gpu-a-[1-4]`      | 128/node | AMD Epyc 7742             | 2 TB/node   | 4 x A100(40GB)/node |
+| `gpu-b-[1-6]`      | 128/node | AMD Epyc 7742             | 512 GB/node | 4 x A6000/node      |
+| `gpu-c-1`          | 30/node  | AMD Epyc 7773X            | 480 GB/node | 8 x A40 / node      |
+| `gpu-d-[1-2]`      | 128/node | AMD Epyc 7773X            | 2 TB/node   | 4 x A100(80GB)/node |
+| `gpu-e-[1-8]`      | 16/node  | AMD Epyc 7313P            | 512 GB/node | 1 x A40 / node      |
+| `gpu-f-[1-6]`      | 112/node | INTEL Xeon Platinum 8480c | 2 TB/node   | 8 x H100 / node     |
+| `gpu-g-[1-2]`      | 64/node  | AMD EPYC 9334             | 1 TB/node   | 4 x L40S / node     |
+| `gpu-h-[1-6,8]`    | 64/node  | INTEL Xeon Platinum 8592+ | 2 TB/node   | 8 x H200 / node     |
+| `gpu-sm01-[01-20]` | 16/node  | AMD Epyc 7302P            | 256 GB/node | 1 x A40 / node      |
+| `gpu-sm02-[01-20]` | 16/node  | AMD Epyc 7302P            | 256 GB/node | 1 x A40 / node      |
 
-
-*Note: Change*
-
-* Total User Partitions CPU cores: 
-    * Today: 2336
-    * EOY: 3296
-* Total GPUs: 
-    * Today: 107
-    * EOY: 111
+* Total User Partitions CPU cores: 5568
+* Total GPUs: 216
 
 <hr>
 
 ### GPU Summary
 
-| GPU Type       | Bruno Total            |
-| :------------: | :--------------------: |
-| A100 (40 GB)   | 16                     |
-| A100 (80 GB)   | 8                      |
-| A6000 (48 GB)  | 24                     |
-| A40 (48GB)     | 48                     |
-| H100 (80 GB) | 48 |
+| GPU Type       | Bruno Total |
+| :------------: | :---------: |
+| A100 (40 GB)   | 16          |
+| A100 (80 GB)   | 8           |
+| A6000 (48 GB)  | 24          |
+| A40 (48GB)     | 56          |
+| H100 (80 GB)   | 48          |
+| H200 (141 GB)  | 56          |
+| L40S (48 GB)   | 8           |
 
 
 ### Storage Nodes/Appliances
@@ -73,7 +69,7 @@ description: Description/listing of what resources are currently in Bruno
 | `czii-gpu-c-[1-3]` | 128/node  | AMD EPYC 9334 32-Core Processor             | 2.3TB/node | 4x NVIDIA A40        |
 | `czii-gpu-d-1`     | 128/node  | Intel(R) Xeon(R) Gold 6438Y+                | 1T/node    | 4x NVIDIA RTX 6000   |
 
-## CHI 
+## CHI
 
 
 | Name               | Cores   | CPU Type                         | Memory    | GPUs |


### PR DESCRIPTION
@nesoquist I added the hardware specs for CHI and CZI, but i dont have access to CHI nodes to get the details, would you be able to retrieve this information and update this.

I removed TmpFS column i dont think users need to know about this and its probably hard to keep this up to date, better keep it out.